### PR TITLE
Add Shuttle deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,28 @@
 # Orca Whirlpool Dashboard
 
-A Rust Actix Web backend with a React frontend.
+This project consists of a Rust backend and a React frontend. Everything is deployed using [Shuttle](https://www.shuttle.rs/) so there is no AWS, ECS or Terraform in the workflow.
 
-## Running locally
+## Prerequisites
 
-1. Build the frontend assets:
+```bash
+curl -Ls https://www.shuttle.rs/install | bash  # installs `cargo-shuttle`
+rustup default stable
+corepack enable                                 # installs pnpm
+```
+
+## Repository structure
+
+```
+.
+├─ backend/    # actix-web service (Shuttle binary)
+└─ frontend/   # Vite React UI
+```
+
+`Shuttle.toml` declares the static assets copied from `frontend/dist` during deploy.
+
+## Building and running locally
+
+1. Build the frontend:
 
 ```bash
 cd frontend
@@ -12,9 +30,33 @@ pnpm install
 pnpm build
 ```
 
-2. Run the backend:
+2. Run the backend with Shuttle:
 
 ```bash
 cd ..
-shuttle run --debug --secrets backend/Secrets.toml
+cargo shuttle run -p backend -- --secrets backend/Secrets.toml
 ```
+
+## Production deploy
+
+Build the frontend and deploy the workspace:
+
+```bash
+cd frontend && pnpm install && pnpm build && cd ..
+cargo shuttle deploy --workspace
+```
+
+Shuttle uploads the backend binary, serves the static files from `frontend/dist` and provides a public URL.
+
+## Continuous deployment
+
+`.github/workflows/ci.yml` can run tests and deploy automatically:
+
+```yaml
+- run: pnpm --filter frontend install --frozen-lockfile
+- run: pnpm --filter frontend build
+- run: cargo test --workspace
+- run: cargo shuttle deploy --workspace --no-test --token ${{ secrets.SHUTTLE_TOKEN }}
+```
+
+Logs and metrics are available in [console.shuttle.rs](https://console.shuttle.rs/).


### PR DESCRIPTION
## Summary
- document how to deploy using Shuttle only

## Testing
- `cargo test --workspace`
- `pnpm build` in `frontend/`


------
https://chatgpt.com/codex/tasks/task_e_687a91fda740832fbf03353fa30fad8d